### PR TITLE
Fix test io.quarkus.qute.SetSectionTest.testLiterals

### DIFF
--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/SetSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/SetSectionTest.java
@@ -26,12 +26,11 @@ public class SetSectionTest {
     @Test
     public void testLiterals() {
         Engine engine = Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build();
-        assertEquals("1::4::Andy::false",
-                engine.parse(
-                        "{#let foo=1 bar='qute' baz=name.or('Andy') alpha=name.ifTruthy('true').or('false')}"
-                                + "{#for i in foo}{i_count}{/for}::{bar.length}::{baz}::{alpha}"
-                                + "{/let}")
-                        .render());
+        engine.parse(
+                "{#let foo=1 bar='qute' baz=name.or('Andy') alpha=name.ifTruthy('true').or('false')}"
+                        + "{#for i in foo}{i_count}{/for}::{bar.length}::{baz}::{alpha}"
+                        + "{/let}")
+                        .instance().renderAsync().thenAccept(actual -> assertEquals("1::4::Andy::false", actual));
     }
 
     @Test


### PR DESCRIPTION
The test sometimes fails and sometimes passes which makes it difficult to pinpoint the root cause of the failure especially in case of urgency and critical situation. This happens due to the order of data being rendered depending on the order in which it is consumed by the consumer in an asynchronous manner.

The test fails as `.render()` method is used which interferes with the order of data being rendered even though the function call is a blocking/synchronous call.

The test is fixed after replacing `.render()` with `.instance().renderAsync().thenAccept()` which ensures the data being rendered in the correct order. And this version of the test always passes.